### PR TITLE
Get Groups By User ID

### DIFF
--- a/api/routes/groupRoutes.js
+++ b/api/routes/groupRoutes.js
@@ -23,11 +23,11 @@ router.get("/", (req, res) => {
     .catch(err => res.status(500).json(err.message));
 });
 
-// GET groupS BY ID //
+// GET groupS By UserID //
 
 router.get("/:id", (req, res) => {
   const { id } = req.params;
-  db.getById(id)
+  db.getByUser(id)
     .then(group => {
       if (group.length >= 1) {
         return res.status(200).json({ data: group });


### PR DESCRIPTION
We're currently getting groups by the group's id itself, not by the owner of the groups. We could make a different endpoint to get a specific group by it's ID if we need it, but I don't think we will. We'll fetch them as soon as they log in and keep them in state from dashboard, so we should never need it.